### PR TITLE
Ingestor Work - Polly Update and Other Small Changes

### DIFF
--- a/reference-implementations/semantic-search-for-images/src/ingestion/Constants.cs
+++ b/reference-implementations/semantic-search-for-images/src/ingestion/Constants.cs
@@ -10,6 +10,6 @@ namespace ingestion
         public const string DATA_TABLE_COLUMN_NAME_TITLE = "title";
         public const string DATA_TABLE_COLUMN_NAME_CREATION_DATE = "creationDate";
         public const string NAMED_HTTP_CLIENT_AI_SERVICES = "AiServices";
-        public const string NAMED_RESILIENCE_PIPELINE = "ResiliencePipeline";
+        public const string NAMED_HTTP_CLIENT_GENERAL = "General";
     }
 }

--- a/reference-implementations/semantic-search-for-images/src/ingestion/Services/CosmosDbService.cs
+++ b/reference-implementations/semantic-search-for-images/src/ingestion/Services/CosmosDbService.cs
@@ -35,6 +35,7 @@ namespace ingestion.Services
             // Connect to a cosmos db container using DefaultAzureCredential
             var cosmosClient = new CosmosClient(_appSettings.CosmosDb.Uri, new DefaultAzureCredential());
             var cosmosDb = await cosmosClient.CreateDatabaseIfNotExistsAsync(_appSettings.CosmosDb.Database);
+
             List<Embedding> embeddings = new List<Embedding>()
             {
                 new Embedding()
@@ -45,7 +46,9 @@ namespace ingestion.Services
                     Dimensions = 1024
                 }
             };
+
             Collection<Embedding> collection = new Collection<Embedding>(embeddings);
+            
             ContainerProperties containerProperties = new ContainerProperties(id: _appSettings.CosmosDb.ImageMetadataContainer, partitionKeyPath: _appSettings.CosmosDb.PartitionKey)
             {   
                 VectorEmbeddingPolicy = new(collection),

--- a/reference-implementations/semantic-search-for-images/src/ingestion/Services/DataIngestor.cs
+++ b/reference-implementations/semantic-search-for-images/src/ingestion/Services/DataIngestor.cs
@@ -46,7 +46,7 @@ namespace ingestion {
                 try {
                     _logger.LogInformation($"Processing blob: {blobItem.Name}");
 
-                    MemoryStream memoryStream = new MemoryStream();
+                    using var memoryStream = new MemoryStream();
                     await _blobService.DownloadImageCsvBlob(blobItem.Name, memoryStream);
 
                     records = _csvService.GetRecords(memoryStream);

--- a/reference-implementations/semantic-search-for-images/src/ingestion/ingestion.csproj
+++ b/reference-implementations/semantic-search-for-images/src/ingestion/ingestion.csproj
@@ -21,10 +21,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Polly.Core" Version="8.4.1" />
-    <PackageReference Include="Polly.Extensions" Version="8.4.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removed Polly and now use the standard resilience handler for http clients.  Adjusted memory stream usage to now be properly disposed.